### PR TITLE
feat: update transcube to 0.1.9

### DIFF
--- a/Casks/transcube.rb
+++ b/Casks/transcube.rb
@@ -1,6 +1,6 @@
 cask "transcube" do
-  version "0.1.8"
-  sha256 "fd1595426417d499af4c6cb7f8444cc98d119b9cdf9ee0a6a38fd49b7c984698"
+  version "0.1.9"
+  sha256 "fdd867233cef9056519f2d8978827a196df2e147a8231d72895ca08faff394ca"
 
   url "https://github.com/STRRL/transcube-webapp/releases/download/v#{version}/TransCube-#{version}-macOS.dmg"
   name "TransCube"


### PR DESCRIPTION
Update transcube cask from 0.1.8 to 0.1.9 with correct SHA256 checksum.

SHA256 verified from GitHub release API: `fdd867233cef9056519f2d8978827a196df2e147a8231d72895ca08faff394ca`

Closes #5

Generated with [Claude Code](https://claude.ai/code)